### PR TITLE
Cache Git credentials

### DIFF
--- a/appcircle_git_clone/1.0.1/component.yaml
+++ b/appcircle_git_clone/1.0.1/component.yaml
@@ -1,0 +1,59 @@
+platform: Common
+buildPlatform:
+displayName: Git Clone
+description: Clone the selected repository to the build machine.
+webUrl: https://github.com/appcircleio/appcircle-git-clone-component
+repoUrl: https://github.com/appcircleio/appcircle-git-clone-component.git
+commit: 5ba4c41
+inputs:
+- key: "AC_GIT_URL"
+  defaultValue: "$AC_GIT_URL"
+  isRequired: true
+  title: Git Url
+  description: Url of the repository.
+  helpText:
+- key: "AC_GIT_COMMIT"
+  defaultValue: "$AC_GIT_COMMIT"
+  isRequired: false
+  title: Commit
+  description: Commit of the repository.
+  helpText:
+- key: "AC_GIT_BRANCH"
+  defaultValue: "$AC_GIT_BRANCH"
+  isRequired: false
+  title: Branch
+  description: Branch of the repository.
+  helpText:
+- key: "AC_GIT_TAG"
+  isRequired: false
+  title: Tag
+  description: Tag of the repository.
+  helpText:
+- key: "AC_GIT_LFS"
+  defaultValue: "false"
+  isRequired: false
+  title: Large File Storage
+  description: Used to specify whether large files will be downloaded.
+  helpText:
+- key: "AC_GIT_SUBMODULE"
+  isRequired: false
+  title: Submodule
+  description: Used to specify whether the submodule should be cloned.
+  helpText:
+- key: "AC_GIT_CACHE_CREDENTIALS"
+  isRequired: false
+  defaultValue: "true"
+  title: Cache Credentials
+  description: If this set to true, the credentials will be cached. This can be useful if same credentials are used for multiple repositories.
+  helpText:
+outputs:
+- key: "AC_REPOSITORY_DIR"
+  title: Repository Directory
+  defaultValue: "AC_REPOSITORY_DIR"
+  description: Specifies the cloned repository directory.
+  helpText:
+processFilename: ruby
+processArguments: '%AC_STEP_TEMP%/main.rb'
+files:
+- "main.rb"
+- "git_clone.sh"


### PR DESCRIPTION
Cache Git credentials to memory. This can be useful if the same credentials are used for multiple repositories. This behavior can be disabled if `AC_GIT_CACHE_CREDENTIALS` is set to false.