### PR TITLE
#BE-800 Add cache provider to pull and push

### DIFF
--- a/appcircle_android_flutter_cache_push/1.0.1/component.yaml
+++ b/appcircle_android_flutter_cache_push/1.0.1/component.yaml
@@ -1,0 +1,35 @@
+platform: Android
+buildPlatform: Flutter
+displayName: "Cache Push"
+description: "Uploads user selected files and folders to Appcircle cache."
+webUrl: https://github.com/appcircleio/appcircle-cache-push-component
+repoUrl: https://github.com/appcircleio/appcircle-cache-push-component.git
+commit: ab0c2ac
+inputs:
+- key: "AC_CACHE_LABEL"
+  defaultValue: "$AC_BUILD_PROFILE_ID/$AC_GIT_BRANCH/cache"
+  isRequired: true
+  title: Cache Label
+  description: "User defined cache label to identify one cache from others. Both cache push and pull steps should have the same value to match."
+  helpText:
+- key: "AC_CACHE_INCLUDED_PATHS"
+  defaultValue: ".gradle:~/.gradle:~/.pub-cache"
+  isRequired: true
+  title: Included Paths
+  description: "Specifies the files and folders which should be in cache. Multiple glob patterns can be provided as a colon-separated list. For example; .gradle:app/build"
+  helpText:
+- key: "AC_CACHE_EXCLUDED_PATHS"
+  defaultValue: ".gradle/**/*.lock:~/.gradle/caches/**/*.lock"
+  isRequired: false
+  title: Excluded Paths
+  description: "Specifies the files and folders which should be ignored from cache. Multiple glob patterns can be provided as a colon-separated list. For example; .gradle/*.lock:*.apk"
+  helpText:
+- key: "AC_REPOSITORY_DIR"
+  defaultValue: "$AC_REPOSITORY_DIR"
+  isRequired: false
+  title: Repository Path
+  description: "Specifies the cloned repository path."
+processFilename: ruby
+processArguments: '%AC_STEP_TEMP%/main.rb'
+files:
+- "main.rb"

--- a/appcircle_android_javakotlin_cache_push/1.0.1/component.yaml
+++ b/appcircle_android_javakotlin_cache_push/1.0.1/component.yaml
@@ -1,0 +1,35 @@
+platform: Android
+buildPlatform: JavaKotlin
+displayName: "Cache Push"
+description: "Uploads user selected files and folders to Appcircle cache."
+webUrl: https://github.com/appcircleio/appcircle-cache-push-component
+repoUrl: https://github.com/appcircleio/appcircle-cache-push-component.git
+commit: ab0c2ac
+inputs:
+- key: "AC_CACHE_LABEL"
+  defaultValue: "$AC_BUILD_PROFILE_ID/$AC_GIT_BRANCH/cache"
+  isRequired: true
+  title: Cache Label
+  description: "User defined cache label to identify one cache from others. Both cache push and pull steps should have the same value to match."
+  helpText:
+- key: "AC_CACHE_INCLUDED_PATHS"
+  defaultValue: ".gradle:~/.gradle"
+  isRequired: true
+  title: Included Paths
+  description: "Specifies the files and folders which should be in cache. Multiple glob patterns can be provided as a colon-separated list. For example; .gradle:app/build"
+  helpText:
+- key: "AC_CACHE_EXCLUDED_PATHS"
+  defaultValue: ".gradle/**/*.lock:~/.gradle/caches/**/*.lock"
+  isRequired: false
+  title: Excluded Paths
+  description: "Specifies the files and folders which should be ignored from cache. Multiple glob patterns can be provided as a colon-separated list. For example; .gradle/*.lock:*.apk"
+  helpText:
+- key: "AC_REPOSITORY_DIR"
+  defaultValue: "$AC_REPOSITORY_DIR"
+  isRequired: false
+  title: Repository Path
+  description: "Specifies the cloned repository path."
+processFilename: ruby
+processArguments: '%AC_STEP_TEMP%/main.rb'
+files:
+- "main.rb"

--- a/appcircle_android_reactnative_cache_push/1.0.1/component.yaml
+++ b/appcircle_android_reactnative_cache_push/1.0.1/component.yaml
@@ -1,0 +1,35 @@
+platform: Android
+buildPlatform: ReactNative
+displayName: "Cache Push"
+description: "Uploads user selected files and folders to Appcircle cache."
+webUrl: https://github.com/appcircleio/appcircle-cache-push-component
+repoUrl: https://github.com/appcircleio/appcircle-cache-push-component.git
+commit: ab0c2ac
+inputs:
+- key: "AC_CACHE_LABEL"
+  defaultValue: "$AC_BUILD_PROFILE_ID/$AC_GIT_BRANCH/cache"
+  isRequired: true
+  title: Cache Label
+  description: "User defined cache label to identify one cache from others. Both cache push and pull steps should have the same value to match."
+  helpText:
+- key: "AC_CACHE_INCLUDED_PATHS"
+  defaultValue: ".gradle:~/.gradle:/usr/local/share/.cache/yarn"
+  isRequired: true
+  title: Included Paths
+  description: "Specifies the files and folders which should be in cache. Multiple glob patterns can be provided as a colon-separated list. For example; .gradle:app/build"
+  helpText:
+- key: "AC_CACHE_EXCLUDED_PATHS"
+  defaultValue: ".gradle/**/*.lock:~/.gradle/caches/**/*.lock"
+  isRequired: false
+  title: Excluded Paths
+  description: "Specifies the files and folders which should be ignored from cache. Multiple glob patterns can be provided as a colon-separated list. For example; .gradle/*.lock:*.apk"
+  helpText:
+- key: "AC_REPOSITORY_DIR"
+  defaultValue: "$AC_REPOSITORY_DIR"
+  isRequired: false
+  title: Repository Path
+  description: "Specifies the cloned repository path."
+processFilename: ruby
+processArguments: '%AC_STEP_TEMP%/main.rb'
+files:
+- "main.rb"

--- a/appcircle_android_smartface_cache_push/1.0.1/component.yaml
+++ b/appcircle_android_smartface_cache_push/1.0.1/component.yaml
@@ -1,0 +1,35 @@
+platform: Android
+buildPlatform: Smartface
+displayName: "Cache Push"
+description: "Uploads user selected files and folders to Appcircle cache."
+webUrl: https://github.com/appcircleio/appcircle-cache-push-component
+repoUrl: https://github.com/appcircleio/appcircle-cache-push-component.git
+commit: ab0c2ac
+inputs:
+- key: "AC_CACHE_LABEL"
+  defaultValue: "$AC_BUILD_PROFILE_ID/$AC_GIT_BRANCH/cache"
+  isRequired: true
+  title: Cache Label
+  description: "User defined cache label to identify one cache from others. Both cache push and pull steps should have the same value to match."
+  helpText:
+- key: "AC_CACHE_INCLUDED_PATHS"
+  defaultValue: ".gradle:~/.gradle"
+  isRequired: true
+  title: Included Paths
+  description: "Specifies the files and folders which should be in cache. Multiple glob patterns can be provided as a colon-separated list. For example; .gradle:app/build"
+  helpText:
+- key: "AC_CACHE_EXCLUDED_PATHS"
+  defaultValue: ".gradle/**/*.lock:~/.gradle/caches/**/*.lock"
+  isRequired: false
+  title: Excluded Paths
+  description: "Specifies the files and folders which should be ignored from cache. Multiple glob patterns can be provided as a colon-separated list. For example; .gradle/*.lock:*.apk"
+  helpText:
+- key: "AC_REPOSITORY_DIR"
+  defaultValue: "$AC_REPOSITORY_DIR"
+  isRequired: false
+  title: Repository Path
+  description: "Specifies the cloned repository path."
+processFilename: ruby
+processArguments: '%AC_STEP_TEMP%/main.rb'
+files:
+- "main.rb"

--- a/appcircle_cache_pull/1.0.2/component.yaml
+++ b/appcircle_cache_pull/1.0.2/component.yaml
@@ -1,0 +1,23 @@
+platform: Common
+buildPlatform:
+displayName: "Cache Pull"
+description: "Downloads cache from Appcircle, extracts files and folders to source locations."
+webUrl: https://github.com/appcircleio/appcircle-cache-pull-component
+repoUrl: https://github.com/appcircleio/appcircle-cache-pull-component.git
+commit: 361caf8
+inputs:
+- key: "AC_CACHE_LABEL"
+  defaultValue: "$AC_BUILD_PROFILE_ID/$AC_GIT_BRANCH/cache"
+  isRequired: true
+  title: Cache Label
+  description: "User defined cache label to identify one cache from others. Both cache push and pull steps should have the same value to match."
+  helpText:
+- key: "AC_REPOSITORY_DIR"
+  defaultValue: "$AC_REPOSITORY_DIR"
+  isRequired: false
+  title: Repository Path
+  description: "Specifies the cloned repository path."
+processFilename: ruby
+processArguments: '%AC_STEP_TEMP%/main.rb'
+files:
+- "main.rb"

--- a/appcircle_ios_flutter_cache_push/1.0.1/component.yaml
+++ b/appcircle_ios_flutter_cache_push/1.0.1/component.yaml
@@ -1,0 +1,35 @@
+platform: iOS
+buildPlatform: Flutter
+displayName: "Cache Push"
+description: "Uploads user selected files and folders to Appcircle cache."
+webUrl: https://github.com/appcircleio/appcircle-cache-push-component
+repoUrl: https://github.com/appcircleio/appcircle-cache-push-component.git
+commit: ab0c2ac
+inputs:
+- key: "AC_CACHE_LABEL"
+  defaultValue: "$AC_BUILD_PROFILE_ID/$AC_GIT_BRANCH/cache"
+  isRequired: true
+  title: Cache Label
+  description: "User defined cache label to identify one cache from others. Both cache push and pull steps should have the same value to match."
+  helpText:
+- key: "AC_CACHE_INCLUDED_PATHS"
+  defaultValue: "~/Library/Caches/CocoaPods:~/.pub-cache"
+  isRequired: true
+  title: Included Paths
+  description: "Specifies the files and folders which should be in cache. Multiple glob patterns can be provided as a colon-separated list. For example; .gradle:app/build"
+  helpText:
+- key: "AC_CACHE_EXCLUDED_PATHS"
+  defaultValue: ""
+  isRequired: false
+  title: Excluded Paths
+  description: "Specifies the files and folders which should be ignored from cache. Multiple glob patterns can be provided as a colon-separated list. For example; .gradle/*.lock:*.apk"
+  helpText:
+- key: "AC_REPOSITORY_DIR"
+  defaultValue: "$AC_REPOSITORY_DIR"
+  isRequired: false
+  title: Repository Path
+  description: "Specifies the cloned repository path."
+processFilename: ruby
+processArguments: '%AC_STEP_TEMP%/main.rb'
+files:
+- "main.rb"

--- a/appcircle_ios_objectivecswift_cache_push/1.0.1/component.yaml
+++ b/appcircle_ios_objectivecswift_cache_push/1.0.1/component.yaml
@@ -1,0 +1,35 @@
+platform: iOS
+buildPlatform: ObjectiveCSwift
+displayName: "Cache Push"
+description: "Uploads user selected files and folders to Appcircle cache."
+webUrl: https://github.com/appcircleio/appcircle-cache-push-component
+repoUrl: https://github.com/appcircleio/appcircle-cache-push-component.git
+commit: ab0c2ac
+inputs:
+- key: "AC_CACHE_LABEL"
+  defaultValue: "$AC_BUILD_PROFILE_ID/$AC_GIT_BRANCH/cache"
+  isRequired: true
+  title: Cache Label
+  description: "User defined cache label to identify one cache from others. Both cache push and pull steps should have the same value to match."
+  helpText:
+- key: "AC_CACHE_INCLUDED_PATHS"
+  defaultValue: "~/Library/Caches/CocoaPods"
+  isRequired: true
+  title: Included Paths
+  description: "Specifies the files and folders which should be in cache. Multiple glob patterns can be provided as a colon-separated list. For example; .gradle:app/build"
+  helpText:
+- key: "AC_CACHE_EXCLUDED_PATHS"
+  defaultValue: ""
+  isRequired: false
+  title: Excluded Paths
+  description: "Specifies the files and folders which should be ignored from cache. Multiple glob patterns can be provided as a colon-separated list. For example; .gradle/*.lock:*.apk"
+  helpText:
+- key: "AC_REPOSITORY_DIR"
+  defaultValue: "$AC_REPOSITORY_DIR"
+  isRequired: false
+  title: Repository Path
+  description: "Specifies the cloned repository path."
+processFilename: ruby
+processArguments: '%AC_STEP_TEMP%/main.rb'
+files:
+- "main.rb"

--- a/appcircle_ios_reactnative_cache_push/1.0.1/component.yaml
+++ b/appcircle_ios_reactnative_cache_push/1.0.1/component.yaml
@@ -1,0 +1,35 @@
+platform: iOS
+buildPlatform: ReactNative
+displayName: "Cache Push"
+description: "Uploads user selected files and folders to Appcircle cache."
+webUrl: https://github.com/appcircleio/appcircle-cache-push-component
+repoUrl: https://github.com/appcircleio/appcircle-cache-push-component.git
+commit: ab0c2ac
+inputs:
+- key: "AC_CACHE_LABEL"
+  defaultValue: "$AC_BUILD_PROFILE_ID/$AC_GIT_BRANCH/cache"
+  isRequired: true
+  title: Cache Label
+  description: "User defined cache label to identify one cache from others. Both cache push and pull steps should have the same value to match."
+  helpText:
+- key: "AC_CACHE_INCLUDED_PATHS"
+  defaultValue: "~/Library/Caches/CocoaPods:~/Library/Caches/Yarn"
+  isRequired: true
+  title: Included Paths
+  description: "Specifies the files and folders which should be in cache. Multiple glob patterns can be provided as a colon-separated list. For example; .gradle:app/build"
+  helpText:
+- key: "AC_CACHE_EXCLUDED_PATHS"
+  defaultValue: ""
+  isRequired: false
+  title: Excluded Paths
+  description: "Specifies the files and folders which should be ignored from cache. Multiple glob patterns can be provided as a colon-separated list. For example; .gradle/*.lock:*.apk"
+  helpText:
+- key: "AC_REPOSITORY_DIR"
+  defaultValue: "$AC_REPOSITORY_DIR"
+  isRequired: false
+  title: Repository Path
+  description: "Specifies the cloned repository path."
+processFilename: ruby
+processArguments: '%AC_STEP_TEMP%/main.rb'
+files:
+- "main.rb"

--- a/appcircle_ios_smartface_cache_push/1.0.1/component.yaml
+++ b/appcircle_ios_smartface_cache_push/1.0.1/component.yaml
@@ -1,0 +1,35 @@
+platform: iOS
+buildPlatform: Smartface
+displayName: "Cache Push"
+description: "Uploads user selected files and folders to Appcircle cache."
+webUrl: https://github.com/appcircleio/appcircle-cache-push-component
+repoUrl: https://github.com/appcircleio/appcircle-cache-push-component.git
+commit: ab0c2ac
+inputs:
+- key: "AC_CACHE_LABEL"
+  defaultValue: "$AC_BUILD_PROFILE_ID/$AC_GIT_BRANCH/cache"
+  isRequired: true
+  title: Cache Label
+  description: "User defined cache label to identify one cache from others. Both cache push and pull steps should have the same value to match."
+  helpText:
+- key: "AC_CACHE_INCLUDED_PATHS"
+  defaultValue: "~/Library/Caches/CocoaPods"
+  isRequired: true
+  title: Included Paths
+  description: "Specifies the files and folders which should be in cache. Multiple glob patterns can be provided as a colon-separated list. For example; .gradle:app/build"
+  helpText:
+- key: "AC_CACHE_EXCLUDED_PATHS"
+  defaultValue: ""
+  isRequired: false
+  title: Excluded Paths
+  description: "Specifies the files and folders which should be ignored from cache. Multiple glob patterns can be provided as a colon-separated list. For example; .gradle/*.lock:*.apk"
+  helpText:
+- key: "AC_REPOSITORY_DIR"
+  defaultValue: "$AC_REPOSITORY_DIR"
+  isRequired: false
+  title: Repository Path
+  description: "Specifies the cloned repository path."
+processFilename: ruby
+processArguments: '%AC_STEP_TEMP%/main.rb'
+files:
+- "main.rb"


### PR DESCRIPTION
For self-hosted appcircle deployment, there is a different `curl` request. So we changed `curl` call conditionally. (_gcloud, filesystem_)

Both cache pull and push components have updates.