### PR TITLE
Bump Git Clone and cache component versions

### DIFF
--- a/appcircle_android_flutter_cache_push/1.0.7/component.yaml
+++ b/appcircle_android_flutter_cache_push/1.0.7/component.yaml
@@ -1,0 +1,39 @@
+platform: Android
+buildPlatform: Flutter
+displayName: "Cache Push"
+description: "Uploads user selected files and folders to Appcircle cache."
+docsUrl: https://docs.appcircle.io/workflows/common-workflow-steps/build-cache/cache-push
+requiredComponents: "appcircle_git_clone"
+precedingComponents:
+followingComponents: "appcircle_export_build_artifacts"
+webUrl: https://github.com/appcircleio/appcircle-cache-push-component
+repoUrl: https://github.com/appcircleio/appcircle-cache-push-component.git
+commit: 9a7aa2e
+inputs:
+- key: "AC_CACHE_LABEL"
+  defaultValue: "$AC_BUILD_PROFILE_ID/cache"
+  isRequired: true
+  title: Cache Label
+  description: "User defined cache label to identify one cache from others. Both cache push and pull steps should have the same value to match."
+  helpText:
+- key: "AC_CACHE_INCLUDED_PATHS"
+  defaultValue: ".gradle:~/.gradle:~/.pub-cache"
+  isRequired: true
+  title: Included Paths
+  description: "Specifies the files and folders which should be in cache. Multiple glob patterns can be provided as a colon-separated list. For example; .gradle:app/build"
+  helpText:
+- key: "AC_CACHE_EXCLUDED_PATHS"
+  defaultValue: ".gradle/**/*.lock:~/.gradle/caches/**/*.lock"
+  isRequired: false
+  title: Excluded Paths
+  description: "Specifies the files and folders which should be ignored from cache. Multiple glob patterns can be provided as a colon-separated list. For example; .gradle/*.lock:*.apk"
+  helpText:
+- key: "AC_REPOSITORY_DIR"
+  defaultValue: "$AC_REPOSITORY_DIR"
+  isRequired: false
+  title: Repository Path
+  description: "Specifies the cloned repository path."
+processFilename: ruby
+processArguments: '%AC_STEP_TEMP%/main.rb'
+files:
+- "main.rb"

--- a/appcircle_android_javakotlin_cache_push/1.0.7/component.yaml
+++ b/appcircle_android_javakotlin_cache_push/1.0.7/component.yaml
@@ -1,0 +1,39 @@
+platform: Android
+buildPlatform: JavaKotlin
+displayName: "Cache Push"
+description: "Uploads user selected files and folders to Appcircle cache."
+docsUrl: https://docs.appcircle.io/workflows/common-workflow-steps/build-cache/cache-push
+requiredComponents: "appcircle_git_clone"
+precedingComponents:
+followingComponents: "appcircle_export_build_artifacts"
+webUrl: https://github.com/appcircleio/appcircle-cache-push-component
+repoUrl: https://github.com/appcircleio/appcircle-cache-push-component.git
+commit: 9a7aa2e
+inputs:
+- key: "AC_CACHE_LABEL"
+  defaultValue: "$AC_BUILD_PROFILE_ID/cache"
+  isRequired: true
+  title: Cache Label
+  description: "User defined cache label to identify one cache from others. Both cache push and pull steps should have the same value to match."
+  helpText:
+- key: "AC_CACHE_INCLUDED_PATHS"
+  defaultValue: ".gradle:~/.gradle"
+  isRequired: true
+  title: Included Paths
+  description: "Specifies the files and folders which should be in cache. Multiple glob patterns can be provided as a colon-separated list. For example; .gradle:app/build"
+  helpText:
+- key: "AC_CACHE_EXCLUDED_PATHS"
+  defaultValue: ".gradle/**/*.lock:~/.gradle/caches/**/*.lock"
+  isRequired: false
+  title: Excluded Paths
+  description: "Specifies the files and folders which should be ignored from cache. Multiple glob patterns can be provided as a colon-separated list. For example; .gradle/*.lock:*.apk"
+  helpText:
+- key: "AC_REPOSITORY_DIR"
+  defaultValue: "$AC_REPOSITORY_DIR"
+  isRequired: false
+  title: Repository Path
+  description: "Specifies the cloned repository path."
+processFilename: ruby
+processArguments: '%AC_STEP_TEMP%/main.rb'
+files:
+- "main.rb"

--- a/appcircle_android_reactnative_cache_push/1.0.6/component.yaml
+++ b/appcircle_android_reactnative_cache_push/1.0.6/component.yaml
@@ -1,0 +1,39 @@
+platform: Android
+buildPlatform: ReactNative
+displayName: "Cache Push"
+description: "Uploads user selected files and folders to Appcircle cache."
+docsUrl: https://docs.appcircle.io/workflows/common-workflow-steps/build-cache/cache-push
+requiredComponents: "appcircle_git_clone"
+precedingComponents:
+followingComponents: "appcircle_export_build_artifacts"
+webUrl: https://github.com/appcircleio/appcircle-cache-push-component
+repoUrl: https://github.com/appcircleio/appcircle-cache-push-component.git
+commit: 9a7aa2e
+inputs:
+- key: "AC_CACHE_LABEL"
+  defaultValue: "$AC_BUILD_PROFILE_ID/cache"
+  isRequired: true
+  title: Cache Label
+  description: "User defined cache label to identify one cache from others. Both cache push and pull steps should have the same value to match."
+  helpText:
+- key: "AC_CACHE_INCLUDED_PATHS"
+  defaultValue: ".gradle:~/.gradle:/usr/local/share/.cache/yarn"
+  isRequired: true
+  title: Included Paths
+  description: "Specifies the files and folders which should be in cache. Multiple glob patterns can be provided as a colon-separated list. For example; .gradle:app/build"
+  helpText:
+- key: "AC_CACHE_EXCLUDED_PATHS"
+  defaultValue: ".gradle/**/*.lock:~/.gradle/caches/**/*.lock"
+  isRequired: false
+  title: Excluded Paths
+  description: "Specifies the files and folders which should be ignored from cache. Multiple glob patterns can be provided as a colon-separated list. For example; .gradle/*.lock:*.apk"
+  helpText:
+- key: "AC_REPOSITORY_DIR"
+  defaultValue: "$AC_REPOSITORY_DIR"
+  isRequired: false
+  title: Repository Path
+  description: "Specifies the cloned repository path."
+processFilename: ruby
+processArguments: '%AC_STEP_TEMP%/main.rb'
+files:
+- "main.rb"

--- a/appcircle_cache_pull/1.0.7/component.yaml
+++ b/appcircle_cache_pull/1.0.7/component.yaml
@@ -1,0 +1,27 @@
+platform: Common
+buildPlatform:
+displayName: "Cache Pull"
+description: "Downloads cache from Appcircle, extracts files and folders to source locations."
+docsUrl: https://docs.appcircle.io/workflows/common-workflow-steps/build-cache/cache-pull
+requiredComponents: 
+precedingComponents: "appcircle_git_clone"
+followingComponents: 
+webUrl: https://github.com/appcircleio/appcircle-cache-pull-component
+repoUrl: https://github.com/appcircleio/appcircle-cache-pull-component.git
+commit: 931693b
+inputs:
+- key: "AC_CACHE_LABEL"
+  defaultValue: "$AC_BUILD_PROFILE_ID/cache"
+  isRequired: true
+  title: Cache Label
+  description: "User defined cache label to identify one cache from others. Both cache push and pull steps should have the same value to match."
+  helpText:
+- key: "AC_REPOSITORY_DIR"
+  defaultValue: "$AC_REPOSITORY_DIR"
+  isRequired: false
+  title: Repository Path
+  description: "Specifies the cloned repository path."
+processFilename: ruby
+processArguments: '%AC_STEP_TEMP%/main.rb'
+files:
+- "main.rb"

--- a/appcircle_git_clone/1.1.2/component.yaml
+++ b/appcircle_git_clone/1.1.2/component.yaml
@@ -1,0 +1,69 @@
+platform: Common
+buildPlatform:
+displayName: Git Clone
+description: Clone the selected repository to the build machine.
+docsUrl: https://docs.appcircle.io/workflows/common-workflow-steps/git-clone
+requiredComponents:
+precedingComponents: "appcircle_activate_ssh_key"
+followingComponents:
+webUrl: https://github.com/appcircleio/appcircle-git-clone-component
+repoUrl: https://github.com/appcircleio/appcircle-git-clone-component.git
+commit: 44d318b
+inputs:
+- key: "AC_GIT_URL"
+  defaultValue: "$AC_GIT_URL"
+  isRequired: true
+  title: Git Url
+  description: "Url of the repository."
+  helpText:
+- key: "AC_GIT_COMMIT"
+  defaultValue: "$AC_GIT_COMMIT"
+  isRequired: false
+  title: Commit
+  description: "Commit of the repository."
+  helpText:
+- key: "AC_GIT_BRANCH"
+  defaultValue: "$AC_GIT_BRANCH"
+  isRequired: false
+  title: Branch
+  description: "Branch of the repository."
+  helpText:
+- key: "AC_GIT_TAG"
+  isRequired: false
+  title: Tag
+  description: "Tag of the repository."
+  helpText:
+- key: "AC_GIT_LFS"
+  defaultValue: "false"
+  isRequired: false
+  title: Large File Storage
+  description: "Used to specify whether large files will be downloaded."
+  helpText:
+- key: "AC_GIT_SUBMODULE"
+  isRequired: false
+  title: Submodule
+  description: "Used to specify whether the submodule should be cloned."
+  helpText:
+- key: "AC_GIT_CACHE_CREDENTIALS"
+  isRequired: false
+  defaultValue: "true"
+  title: Cache Credentials
+  description: "If this set to true, the credentials will be cached. This can be useful if the same credentials are used for multiple repositories."
+  helpText:
+- key: "AC_GIT_EXTRA_PARAMS"
+  isRequired: false
+  defaultValue: "$AC_GIT_EXTRA_PARAMS"
+  title: Git Extra Params
+  description: "If this set, sends extra parameter for git requests."
+  helpText:
+outputs:
+- key: "AC_REPOSITORY_DIR"
+  title: Repository Directory
+  defaultValue: "AC_REPOSITORY_DIR"
+  description: "Specifies the cloned repository directory."
+  helpText:
+processFilename: ruby
+processArguments: '%AC_STEP_TEMP%/main.rb'
+files:
+- "main.rb"
+- "git_clone.sh"

--- a/appcircle_ios_flutter_cache_push/1.0.7/component.yaml
+++ b/appcircle_ios_flutter_cache_push/1.0.7/component.yaml
@@ -1,0 +1,39 @@
+platform: iOS
+buildPlatform: Flutter
+displayName: "Cache Push"
+description: "Uploads user selected files and folders to Appcircle cache."
+docsUrl: https://docs.appcircle.io/workflows/common-workflow-steps/build-cache/cache-push
+requiredComponents: "appcircle_git_clone"
+precedingComponents: 
+followingComponents: "appcircle_export_build_artifacts"
+webUrl: https://github.com/appcircleio/appcircle-cache-push-component
+repoUrl: https://github.com/appcircleio/appcircle-cache-push-component.git
+commit: 9a7aa2e
+inputs:
+- key: "AC_CACHE_LABEL"
+  defaultValue: "$AC_BUILD_PROFILE_ID/cache"
+  isRequired: true
+  title: Cache Label
+  description: "User defined cache label to identify one cache from others. Both cache push and pull steps should have the same value to match."
+  helpText:
+- key: "AC_CACHE_INCLUDED_PATHS"
+  defaultValue: "~/Library/Caches/CocoaPods:~/.pub-cache"
+  isRequired: true
+  title: Included Paths
+  description: "Specifies the files and folders which should be in cache. Multiple glob patterns can be provided as a colon-separated list. For example; .gradle:app/build"
+  helpText:
+- key: "AC_CACHE_EXCLUDED_PATHS"
+  defaultValue: ""
+  isRequired: false
+  title: Excluded Paths
+  description: "Specifies the files and folders which should be ignored from cache. Multiple glob patterns can be provided as a colon-separated list. For example; .gradle/*.lock:*.apk"
+  helpText:
+- key: "AC_REPOSITORY_DIR"
+  defaultValue: "$AC_REPOSITORY_DIR"
+  isRequired: false
+  title: Repository Path
+  description: "Specifies the cloned repository path."
+processFilename: ruby
+processArguments: '%AC_STEP_TEMP%/main.rb'
+files:
+- "main.rb"

--- a/appcircle_ios_objectivecswift_cache_push/1.0.7/component.yaml
+++ b/appcircle_ios_objectivecswift_cache_push/1.0.7/component.yaml
@@ -1,0 +1,39 @@
+platform: iOS
+buildPlatform: ObjectiveCSwift
+displayName: "Cache Push"
+description: "Uploads user selected files and folders to Appcircle cache."
+docsUrl: https://docs.appcircle.io/workflows/common-workflow-steps/build-cache/cache-push
+requiredComponents: "appcircle_git_clone"
+precedingComponents:
+followingComponents: "appcircle_export_build_artifacts"
+webUrl: https://github.com/appcircleio/appcircle-cache-push-component
+repoUrl: https://github.com/appcircleio/appcircle-cache-push-component.git
+commit: 9a7aa2e
+inputs:
+- key: "AC_CACHE_LABEL"
+  defaultValue: "$AC_BUILD_PROFILE_ID/cache"
+  isRequired: true
+  title: Cache Label
+  description: "User defined cache label to identify one cache from others. Both cache push and pull steps should have the same value to match."
+  helpText:
+- key: "AC_CACHE_INCLUDED_PATHS"
+  defaultValue: "~/Library/Caches/CocoaPods:Pods:Podfile.lock"
+  isRequired: true
+  title: Included Paths
+  description: "Specifies the files and folders which should be in cache. Multiple glob patterns can be provided as a colon-separated list. For example; .gradle:app/build"
+  helpText:
+- key: "AC_CACHE_EXCLUDED_PATHS"
+  defaultValue: ""
+  isRequired: false
+  title: Excluded Paths
+  description: "Specifies the files and folders which should be ignored from cache. Multiple glob patterns can be provided as a colon-separated list. For example; .gradle/*.lock:*.apk"
+  helpText:
+- key: "AC_REPOSITORY_DIR"
+  defaultValue: "$AC_REPOSITORY_DIR"
+  isRequired: false
+  title: Repository Path
+  description: "Specifies the cloned repository path."
+processFilename: ruby
+processArguments: '%AC_STEP_TEMP%/main.rb'
+files:
+- "main.rb"

--- a/appcircle_ios_reactnative_cache_push/1.0.7/component.yaml
+++ b/appcircle_ios_reactnative_cache_push/1.0.7/component.yaml
@@ -1,0 +1,39 @@
+platform: iOS
+buildPlatform: ReactNative
+displayName: "Cache Push"
+description: "Uploads user selected files and folders to Appcircle cache."
+docsUrl: https://docs.appcircle.io/workflows/common-workflow-steps/build-cache/cache-push
+requiredComponents: "appcircle_git_clone"
+precedingComponents: 
+followingComponents: "appcircle_export_build_artifacts"
+webUrl: https://github.com/appcircleio/appcircle-cache-push-component
+repoUrl: https://github.com/appcircleio/appcircle-cache-push-component.git
+commit: 9a7aa2e 
+inputs:
+- key: "AC_CACHE_LABEL"
+  defaultValue: "$AC_BUILD_PROFILE_ID/cache"
+  isRequired: true
+  title: Cache Label
+  description: "User defined cache label to identify one cache from others. Both cache push and pull steps should have the same value to match."
+  helpText:
+- key: "AC_CACHE_INCLUDED_PATHS"
+  defaultValue: "~/Library/Caches/CocoaPods:~/Library/Caches/Yarn:ios/Pods:ios/Podfile.lock"
+  isRequired: true
+  title: Included Paths
+  description: "Specifies the files and folders which should be in cache. Multiple glob patterns can be provided as a colon-separated list. For example; .gradle:app/build"
+  helpText:
+- key: "AC_CACHE_EXCLUDED_PATHS"
+  defaultValue: ""
+  isRequired: false
+  title: Excluded Paths
+  description: "Specifies the files and folders which should be ignored from cache. Multiple glob patterns can be provided as a colon-separated list. For example; .gradle/*.lock:*.apk"
+  helpText:
+- key: "AC_REPOSITORY_DIR"
+  defaultValue: "$AC_REPOSITORY_DIR"
+  isRequired: false
+  title: Repository Path
+  description: "Specifies the cloned repository path."
+processFilename: ruby
+processArguments: '%AC_STEP_TEMP%/main.rb'
+files:
+- "main.rb"


### PR DESCRIPTION
Adds new catalog versions pinned to the latest component sources for Git Clone and the cache push/pull steps. Each new version folder is a copy of the previous one with only the pinned `commit:` updated.

| Component | New version | Pinned commit |
|---|---|---|
| appcircle_git_clone | 1.1.2 | 44d318b |
| appcircle_cache_pull | 1.0.7 | 931693b |
| appcircle_android_flutter_cache_push | 1.0.7 | 9a7aa2e |
| appcircle_android_javakotlin_cache_push | 1.0.7 | 9a7aa2e |
| appcircle_android_reactnative_cache_push | 1.0.6 | 9a7aa2e |
| appcircle_ios_flutter_cache_push | 1.0.7 | 9a7aa2e |
| appcircle_ios_objectivecswift_cache_push | 1.0.7 | 9a7aa2e |
| appcircle_ios_reactnative_cache_push | 1.0.7 | 9a7aa2e |

No input/behavior changes to the step definitions; only the source pin is advanced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Cache Push workflow steps for Android Flutter, Java/Kotlin, React Native, and iOS Flutter, Objective-C/Swift, and React Native projects.
  - Added a common Cache Pull workflow step.
  - Added a Git Clone workflow step with support for branches, tags, commits, LFS, submodules, cached credentials, and extra options.
  - Added configurable cache labels, included paths, excluded paths, repository locations, and Git settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->